### PR TITLE
Add named exports for compiled CSS & digest

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,7 +36,17 @@ const buildCssModulesJS = async (cssFullPath, options) => {
   const jsonStr = JSON.stringify(cssModulesJSON);
   hash.update(cssFullPath);
   const styleId = hash.copy().digest('hex');
-  return `(function(){if (!document.getElementById('${styleId}')) {var ele = document.createElement('style');ele.id = '${styleId}';ele.textContent = \`${result.css}\`;document.head.appendChild(ele);}})();export default ${jsonStr};`;
+  return `
+    (function() {
+      if (!document.getElementById('${styleId}')) {
+        var ele = document.createElement('style');
+        ele.id = '${styleId}';
+        ele.textContent = \`${result.css}\`;
+        document.head.appendChild(ele);
+      }
+    })();
+    export default ${jsonStr};
+  `;
 };
 
 const CssModulesPlugin = (options = {}) => {

--- a/index.js
+++ b/index.js
@@ -33,19 +33,24 @@ const buildCssModulesJS = async (cssFullPath, options) => {
     map: false
   });
 
-  const jsonStr = JSON.stringify(cssModulesJSON);
+  const classNames = JSON.stringify(cssModulesJSON);
   hash.update(cssFullPath);
-  const styleId = hash.copy().digest('hex');
+  const digest = hash.copy().digest('hex');
   return `
+    const digest = '${digest}';
+    const css = \`${result.css}\`;
+
     (function() {
-      if (!document.getElementById('${styleId}')) {
+      if (!document.getElementById(digest)) {
         var ele = document.createElement('style');
-        ele.id = '${styleId}';
-        ele.textContent = \`${result.css}\`;
+        ele.id = digest;
+        ele.textContent = css;
         document.head.appendChild(ele);
       }
     })();
-    export default ${jsonStr};
+
+    export default ${classNames};
+    export { css, digest };
   `;
 };
 

--- a/test/hello.world.jsx
+++ b/test/hello.world.jsx
@@ -1,8 +1,8 @@
 import React from 'react';
-import styles from './app.modules.css';
+import styles, { css, digest } from './app.modules.css';
 
-export const HelloWorld = () => {
-  return (
-    <h3 className={styles.helloWorld}>Hello World!</h3>
-  );
-};
+export const HelloWorld = () => <>
+  <h3 className={styles.helloWorld}>Hello World!</h3>
+  <code>{digest}</code>
+  <pre><code>{css}</code></pre>
+</>


### PR DESCRIPTION
This PR adds two named exports, `css` & `digest`, that can be used in addition to the default classname list export. `css` is the compiled CSS string (with generated classnames) and `digest` which is a hex digest of the CSS module file path (this is already used as the ID of the inserted `<style>` tag).

This is a non-breaking change.

## Why?

The default behaviour of automatically inserting the generated css in the `<head>` is great for the majority of use cases, but there are situations where the component needs access to its own styles, for example when working with Web Components and rendering a component in the Shadow DOM. With the default behaviour, the styles inserted in the `<head>` have no effect within the Shadow DOM.

This change allows a component to render its styles directly (with its own `<style>` tag). The `digest` can be used to implement a custom check to prevent duplicate insertion by a parent component, or it can be used to query the inserted `<style>` element in the `<head>` by its ID.

## Follow-Up: Disabling Automatic Insertion
I will open a follow-up PR to add an option to the plugin to _disable_ the automatic insertion of the styles in the `<head>`, as when a component renders its own styles there is no reason to "pollute" the global styles.