### PR TITLE
add `inject` option to disable injecting styles into `<head>`

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,6 +13,7 @@ const ensureDir = util.promisify(fs.ensureDir);
 const buildCssModulesJS = async (cssFullPath, options) => {
   const {
     localsConvention = 'camelCaseOnly',
+    inject = true,
     generateScopedName
   } = options;
 
@@ -40,14 +41,16 @@ const buildCssModulesJS = async (cssFullPath, options) => {
     const digest = '${digest}';
     const css = \`${result.css}\`;
 
-    (function() {
-      if (!document.getElementById(digest)) {
-        var ele = document.createElement('style');
-        ele.id = digest;
-        ele.textContent = css;
-        document.head.appendChild(ele);
-      }
-    })();
+    ${inject && `
+      (function() {
+        if (!document.getElementById(digest)) {
+          var ele = document.createElement('style');
+          ele.id = digest;
+          ele.textContent = css;
+          document.head.appendChild(ele);
+        }
+      })();
+    `}
 
     export default ${classNames};
     export { css, digest };

--- a/index.js
+++ b/index.js
@@ -36,7 +36,17 @@ const buildCssModulesJS = async (cssFullPath, options) => {
   const jsonStr = JSON.stringify(cssModulesJSON);
   hash.update(cssFullPath);
   const styleId = hash.copy().digest('hex');
-  return `(function(){if (!document.getElementById('${styleId}')) {var ele = document.createElement('style');ele.id = '${styleId}';ele.textContent = \`${result.css}\`;document.head.appendChild(ele);}})();export default ${jsonStr};`;
+  return `
+    (function() {
+      if (!document.getElementById('${styleId}')) {
+        var ele = document.createElement('style');
+        ele.id = '${styleId}';
+        ele.textContent = \`${result.css}\`;
+        document.head.appendChild(ele);
+      }
+    })();
+    export default ${jsonStr};
+  `;
 };
 
 const CssModulesPlugin = (options = {}) => {

--- a/index.js
+++ b/index.js
@@ -33,19 +33,24 @@ const buildCssModulesJS = async (cssFullPath, options) => {
     map: false
   });
 
-  const jsonStr = JSON.stringify(cssModulesJSON);
+  const classNames = JSON.stringify(cssModulesJSON);
   hash.update(cssFullPath);
-  const styleId = hash.copy().digest('hex');
+  const digest = hash.copy().digest('hex');
   return `
+    const digest = '${digest}';
+    const css = \`${result.css}\`;
+
     (function() {
-      if (!document.getElementById('${styleId}')) {
+      if (!document.getElementById(digest)) {
         var ele = document.createElement('style');
-        ele.id = '${styleId}';
-        ele.textContent = \`${result.css}\`;
+        ele.id = digest;
+        ele.textContent = css;
         document.head.appendChild(ele);
       }
     })();
-    export default ${jsonStr};
+
+    export default ${classNames};
+    export { css, digest };
   `;
 };
 

--- a/readme.md
+++ b/readme.md
@@ -27,6 +27,7 @@ const cssModulesPlugin = require('esbuild-css-modules-plugin');
 esbuild.build({
   plugins: [
     cssModulesPlugin({
+      inject: true, // optional. set to false to not inject generated CSS into <head>, default is true
       localsConvention: 'camelCaseOnly', // optional. value could be one of 'camelCaseOnly', 'camelCase', 'dashes', 'dashesOnly', default is 'camelCaseOnly'
       generateScopedName: (name, filename, css) => string // optional. 
     })

--- a/test/hello.world.jsx
+++ b/test/hello.world.jsx
@@ -1,8 +1,8 @@
 import React from 'react';
-import styles from './app.modules.css';
+import styles, { css, digest } from './app.modules.css';
 
-export const HelloWorld = () => {
-  return (
-    <h3 className={styles.helloWorld}>Hello World!</h3>
-  );
-};
+export const HelloWorld = () => <>
+  <h3 className={styles.helloWorld}>Hello World!</h3>
+  <code>{digest}</code>
+  <pre><code>{css}</code></pre>
+</>

--- a/test/test.js
+++ b/test/test.js
@@ -35,3 +35,22 @@ esbuild.build({
 }).then((result) => {
   console.log('[test][esbuild:no-bundle] done, please check `test/dist/no-bundle`');
 });
+
+esbuild.build({
+  entryPoints: ['app.jsx'],
+  format: 'esm',
+  target: ['es2020'],
+  bundle: true,
+  minify: false,
+  sourcemap: true,
+  external: ['react', 'react-dom'],
+  outdir: './dist/bundle-no-inject',
+  write: true,
+  plugins: [
+    cssModulesPlugin({
+      inject: false
+    })
+  ]
+}).then((result) => {
+  console.log('[test][esbuild:bundle-no-inject] done, please check `test/dist/bundle-no-inject`');
+});


### PR DESCRIPTION
⚠️ **Important:** This PR is built on top of #2 and should be merged (and maybe rebased) _after_ that is merged. That is why the diff includes those changes too, but the only relevant commit is the last one (`dbcd3aa`).

---

This is a follow-up PR to #2. It adds an option that allows a user to _disable_ the automatic injection of the compiled styles into the `<head>` of the document. After #2, a component can render (or export) its own compiled css, which means it no longer needs to be injected automatically.

The default value for this option is `true`, which makes it a non-breaking change.