### PR TITLE
Provide custom injection code for attach to specific DOM node, i.e. shadow DOM.

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,19 +38,21 @@ const buildCssModulesJS = async (cssFullPath, options) => {
   const classNames = JSON.stringify(cssModulesJSON);
   hash.update(cssFullPath);
   const digest = hash.copy().digest('hex');
+  
+  const injectedCode = inject === true ? `(function() {
+  if (!document.getElementById(digest)) {
+    var el = document.createElement('style');
+    el.id = digest;
+    el.textContent = css;
+    document.head.appendChild(el);
+  }
+})();
+  ` : typeof(inject) === 'function' ? inject() : ''
+
   return `
 const digest = '${digest}';
 const css = \`${result.css}\`;
-${inject && `
-(function() {
-  if (!document.getElementById(digest)) {
-    var ele = document.createElement('style');
-    ele.id = digest;
-    ele.textContent = css;
-    document.head.appendChild(ele);
-  }
-})();
-`}
+${injectedCode}
 export default ${classNames};
 export { css, digest };
   `;


### PR DESCRIPTION
Option "inject" can be a function. In that case it'll be called to get injection code. This is helpful to provide code for shadow-DOM attachment instead of document's head.
Usage:
```js
const cssModulesPlugin = require('./esbuild-css-modules-plugin.js');
const shadowContainerId = 'vocab-k09asnd';

const esbuildOptions = {
  ...,
  plugins: [
    cssModulesPlugin({
      inject: () => {
        return `var el = document.getElementById('${shadowContainerId}');
        if (el && el.shadowRoot && !el.shadowRoot.getElementById(digest)) {
            const styleEl = document.createElement('style');
            styleEl.id = digest;
            styleEl.textContent = css;
            el.shadowRoot.prepend(styleEl);
        }
        `
      }
    })
  ]
}

```