### PR TITLE
Fix: user inject function receives unprocessed CSS

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,7 +55,7 @@ const buildCssModulesJS = async (cssFullPath, options) => {
 })();
     `;
   } else if (typeof inject === 'function') {
-    injectedCode = inject(css, digest);
+    injectedCode = inject(result.css, digest);
   }
 
   let jsContent = `


### PR DESCRIPTION
I attempted to use the `inject` function as a config option, as described in the docs:

```js
cssModulesPlugin({
      // optional. set to false to not inject generated CSS into <head>, default is true. 
      // could be a function with params content & digest (return a string of js code to inject to page), 
      // e.g.
      // ```
      // inject: (cssContent, digest) => `console.log("${cssContent}", "${digest}")`
      // ```
    })
```

However, I found that `cssContent` still has the _unprocessed_ class names from my CSS file. This change correctly passes the `result.css` as `cssContent` after postcss processing.

If `cssContent` is supposed to be unprocessed, that's fine! But I'd like to receive the processed classnames in my `inject` function as well, perhaps with a new function parameter?