### PR TITLE
Allow overriding the cssModule filepath resolver

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,8 +53,10 @@ const buildCssModulesJS2 = async (cssFullPath) => {
   };
 };
 
+const defaultResolve = file => file;
+
 const buildCssModulesJS = async (cssFullPath, options) => {
-  const { localsConvention = 'camelCaseOnly', inject = true, generateScopedName } = options;
+  const { resolve = defaultResolve, localsConvention = 'camelCaseOnly', inject = true, generateScopedName } = options;
 
   const css = await readFile(cssFullPath);
 
@@ -63,6 +65,7 @@ const buildCssModulesJS = async (cssFullPath, options) => {
     cssModules({
       localsConvention,
       generateScopedName,
+      resolve,
       getJSON(cssSourceFile, json) {
         cssModulesJSON = { ...json };
         return cssModulesJSON;

--- a/readme.md
+++ b/readme.md
@@ -41,7 +41,16 @@ esbuild.build({
       
       generateScopedName: (name, filename, css) => string, // optional. 
 
-      v2: true // experimental. v2 can bundle images in css, note if set `v2` to true, all other options will be ignored. and v2 only works with `bundle: true`.
+      v2: true, // experimental. v2 can bundle images in css, note if set `v2` to true, all other options will be ignored. and v2 only works with `bundle: true`.
+
+      // optional. If omitted uses the default behavior.
+      // This is used to override the resolved path for modules imported inside of
+      // other modules (I.E. using `from` or `value`). This is expected to be a
+      // function that receives a `file` string representing the full file path
+      // and returns a string representing the modified file path.
+      resolve(file) {
+        return path.resolve(process.cwd(), 'src/styles', file);
+      }
     })
   ]
 });


### PR DESCRIPTION
This allows users of this plugin to override the filepath resolver when
resolving paths to css modules imported from within css modules (i.e.
using `value` or `from` from inside of a module). The default behavior
here was to use absolute paths so the modules were never found.