### PR TITLE
feat: add support for named exports

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -87,7 +87,11 @@ export default new Proxy(${classNamesMapString}, {
   `
     : `export default ${classNamesMapString};`;
 
-  const js = `${importStatement}\n${exportStatement};`;
+  const namedExportStatements = Object.entries(cssModulesJSON).map(
+    ([camelCaseClassName, className]) => `export const ${camelCaseClassName} = "${className}";`
+  ).join('\n');
+
+  const js = `${importStatement}\n${exportStatement};\n${namedExportStatements}`;
 
   return {
     js,

--- a/test/components/named-exports.world.jsx
+++ b/test/components/named-exports.world.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import * as styles from '../styles/app.modules.css';
+import * as styles2 from '../styles/deep/styles/hello.modules.css';
+
+export const HelloWorld = () => (
+  <>
+    <h3 className={styles.helloWorld}>Hello World!</h3>
+    <p className={styles2.helloText}>hi...</p>
+  </>
+);

--- a/test/named-exports.jsx
+++ b/test/named-exports.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDom from 'react-dom';
+
+import { HelloWorld } from './components/named-exports.world';
+
+const App = () => {
+  return <HelloWorld/>;
+};
+
+ReactDom.render(<App/>, document.body);

--- a/test/test.js
+++ b/test/test.js
@@ -74,7 +74,8 @@ fse.emptyDirSync('./dist');
 
   await esbuild.build({
     entryPoints: {
-      ['custom-entry-name']: 'app.jsx'
+      ['custom-entry-name']: 'app.jsx',
+      ['named-exports']: 'named-exports.jsx'
     },
     entryNames: '[name]-[hash]',
     format: 'esm',
@@ -99,7 +100,8 @@ fse.emptyDirSync('./dist');
 
   await esbuild.build({
     entryPoints: {
-      ['custom-entry-name']: 'app.jsx'
+      ['custom-entry-name']: 'app.jsx',
+      ['named-exports']: 'named-exports.jsx'
     },
     entryNames: '[name]-[hash]',
     format: 'esm',
@@ -133,7 +135,7 @@ fse.emptyDirSync('./dist');
   console.log('[test][esbuild:bundle:v2] done, please check `test/dist/bundle-v2-custom-inject`', '\n');
 
   await esbuild.build({
-    entryPoints: ['app.jsx'],
+    entryPoints: ['app.jsx', 'named-exports.jsx'],
     entryNames: '[name]-[hash]',
     format: 'esm',
     target: ['esnext'],


### PR DESCRIPTION
This PR adds support for named export in the plugin v2 implementation.

This is fundamental as a lot of guidelines recommend to use named exports for tree-shaking.

`import * as style from ",.style.module.css";`

Rather than

`import style from ",.style.module.css";`

It does not add support for tree-shaking itself, but it allows the above syntax to work for modules that use it.