### PR TITLE
Add filter option: Regular expression used to match CSS module files

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -46,6 +46,7 @@ declare interface PluginOptions {
   localsConvention?: CssModulesOptions['localsConvention'];
   generateScopedName?: CssModulesOptions['generateScopedName'];
   cssModulesOption?: CssModulesOptions;
+  filter?: RegExp;
   v2?: boolean;
   v2CssModulesOption?: {
     /**

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -9,8 +9,8 @@ const {
   pluginNamespace,
   buildingCssSuffix,
   builtCssSuffix,
-  modulesCssRegExp,
-  builtModulesCssRegExp,
+  getModulesCssRegExp,
+  getBuiltModulesCssRegExp,
   getRelativePath,
   getBuildId
 } = require('./utils.js');
@@ -421,6 +421,8 @@ const onEnd = async (build, options, result) => {
  */
 const setup = async (build, options) => {
   await prepareBuild(build, options);
+  const modulesCssRegExp = getModulesCssRegExp(options);
+  const builtModulesCssRegExp = getBuiltModulesCssRegExp(options);
 
   // resolve xxx.module.css to xxx.module.css?esbuild-css-modules-plugin-building
   build.onResolve({ filter: modulesCssRegExp, namespace: 'file' }, async (args) => {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -6,8 +6,26 @@ const pluginNamespace = `${pluginName}-namespace`;
 const buildingCssSuffix = `?${pluginName}-building`;
 const builtCssSuffix = `?${pluginName}-built`;
 const builtCssSuffixRegExp = builtCssSuffix.replace('?', '\\?').replace(/\-/g, '\\-');
-const modulesCssRegExp = /\.modules?\.css$/i;
-const builtModulesCssRegExp = new RegExp(`\\.modules?\\.css${builtCssSuffixRegExp}$`, 'i');
+
+/**
+ * getModulesCssRegExp
+ * @param {import('..').Options} options
+ * @returns {RegExp}
+ */
+const getModulesCssRegExp = (options) => {
+  return options.filter ?? /\.modules?\.css$/i
+}
+
+/**
+ * getBuiltModulesCssRegExp
+ * @param {import('..').Options} options
+ * @returns {RegExp}
+ */
+const getBuiltModulesCssRegExp = (options) => {
+  const baseRegExp = getModulesCssRegExp(options);
+  const baseRegExpSource = baseRegExp.source.endsWith('$') ? baseRegExp.source.slice(0, -1) : baseRegExp.source;
+  return new RegExp(`${baseRegExpSource}${builtCssSuffixRegExp}$`, 'i');
+}
 
 /**
  * getLogger
@@ -41,7 +59,7 @@ const buildInjectCode = (injectToSelector = 'head', css, digest, options) => {
     delete window.__inject_${digest}__;
   };
   window.__inject_${digest}__ = doInject;
-})();    
+})();
     `;
   }
   return `
@@ -69,7 +87,7 @@ const buildInjectCode = (injectToSelector = 'head', css, digest, options) => {
     delete window.__inject_${digest}__;
   }
   window.__inject_${digest}__ = doInject;
-})();  
+})();
   `;
 };
 
@@ -137,8 +155,8 @@ module.exports = {
   getRootDir,
   buildInjectCode,
   builtCssSuffix,
-  modulesCssRegExp,
-  builtModulesCssRegExp,
+  getModulesCssRegExp,
+  getBuiltModulesCssRegExp,
   buildingCssSuffix,
   getRelativePath,
   getBuildId

--- a/lib/v1.js
+++ b/lib/v1.js
@@ -158,13 +158,17 @@ const onLoadFactory = (build) => (args) => {
  * @returns {Promise<void>}
  */
 const setup = async (build, options) => {
+  const filter = options.filter ?? /\.modules?\.css$/;
+  const filterBaseSource = filter.source.endsWith('$') ? filter.source.slice(0, -1) : filter.source;
+  const filterCssJS = new RegExp(`${filterBaseSource}\\.js$`);
+
   build.onResolve(
-    { filter: /\.modules?\.css$/, namespace: 'file' },
+    { filter, namespace: 'file' },
     onResolveFactory(build, options)
   );
 
   build.onLoad(
-    { filter: /\.modules?\.css\.js$/, namespace: pluginNamespace },
+    { filter: filterCssJS, namespace: pluginNamespace },
     onLoadFactory(build, options)
   );
 };

--- a/readme.md
+++ b/readme.md
@@ -51,6 +51,8 @@ esbuild.build({
 
       generateScopedName: (name, filename, css) => string, // optional. refer to: https://github.com/madyankin/postcss-modules#generating-scoped-names
 
+      filter: /\.modules?\.css$/i // Optional. Regex to filter certain CSS files.
+
       cssModulesOption: {
         // optional, refer to: https://github.com/madyankin/postcss-modules/blob/d7cefc427c43bf35f7ebc55e7bda33b4689baf5a/index.d.ts#L27
         // this option will override others passed to postcss-modules

--- a/test/components/filter.world.jsx
+++ b/test/components/filter.world.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import * as styles from '../styles/app-filter.css';
+import * as styles2 from '../styles/deep/styles/hello-filter.css';
+
+export const HelloWorld = () => (
+  <>
+    <h3 className={styles.helloWorld}>Hello World!</h3>
+    <p className={styles2.helloText}>hi...</p>
+  </>
+);

--- a/test/filter.jsx
+++ b/test/filter.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDom from 'react-dom';
+
+import { HelloWorld } from './components/filter.world';
+
+const App = () => {
+  return <HelloWorld/>;
+};
+
+ReactDom.render(<App/>, document.body);

--- a/test/styles/app-filter.css
+++ b/test/styles/app-filter.css
@@ -1,0 +1,12 @@
+.hello-world {
+  color: red;
+  background: url("../components/world.jpg");
+}
+
+.hello-world:hover {
+  background-image: url(../components/world2.jpg);
+}
+
+.some-other-selector {
+  background-image: url('../components/world.jpg');
+}

--- a/test/styles/deep/styles/hello-filter.css
+++ b/test/styles/deep/styles/hello-filter.css
@@ -1,0 +1,4 @@
+.hello-text {
+  color: red;
+  background: url(../../../components/world.jpg);
+}

--- a/test/test.js
+++ b/test/test.js
@@ -90,9 +90,9 @@ fse.emptyDirSync('./dist');
     loader: {
       '.jpg': 'file'
     },
-    plugins: [cssModulesPlugin({ 
+    plugins: [cssModulesPlugin({
       v2: true,
-      inject: '#my-custom-element-with-shadow-dom' 
+      inject: '#my-custom-element-with-shadow-dom'
     })],
     logLevel: 'debug'
   });
@@ -116,7 +116,7 @@ fse.emptyDirSync('./dist');
     loader: {
       '.jpg': 'dataurl'
     },
-    plugins: [cssModulesPlugin({ 
+    plugins: [cssModulesPlugin({
       v2: true,
       inject: (css, digest) => {
         return `
@@ -128,7 +128,7 @@ fse.emptyDirSync('./dist');
             document.head.appendChild(styleEle);
           }
         `
-      } 
+      }
     })],
     logLevel: 'debug'
   });
@@ -149,11 +149,34 @@ fse.emptyDirSync('./dist');
     loader: {
       '.jpg': 'file'
     },
-    plugins: [cssModulesPlugin({ 
+    plugins: [cssModulesPlugin({
       v2: true,
       inject: false
     })],
     logLevel: 'debug'
   });
   console.log('[test][esbuild:bundle:v2] done, please check `test/dist/bundle-v2-no-inject`', '\n');
+
+  await esbuild.build({
+    entryPoints: ['filter.jsx'],
+    entryNames: '[name]-[hash]',
+    format: 'esm',
+    target: ['esnext'],
+    bundle: true,
+    minify: false,
+    sourcemap: true,
+    publicPath: 'https://my.domain/static/',
+    external: ['react', 'react-dom'],
+    outdir: './dist/bundle-v2-filter',
+    write: true,
+    loader: {
+      '.jpg': 'file'
+    },
+    plugins: [cssModulesPlugin({
+      v2: true,
+      filter: /\.css$/i,
+    })],
+    logLevel: 'debug'
+  });
+  console.log('[test][esbuild:bundle:v2] done, please check `test/dist/bundle-v2-filter`', '\n');
 })();


### PR DESCRIPTION
Allow for CSS module files other than `.modules.css` or `.module.css`.

# Context

In our codebase every CSS file is a CSS module file so we don't end the file name in `.modules.css` or `.module.css`.