### PR TITLE
Support pascal case

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -18,6 +18,7 @@ const {
 } = require('./utils.js');
 const cssHandler = require('@parcel/css');
 const camelCase = require('lodash/camelCase');
+const upperFirst = require('lodash/upperFirst');
 const BuildCache = require('./cache.js');
 
 /**
@@ -58,7 +59,13 @@ const buildCssModulesJs = async ({ fullPath, options, build }) => {
     .sort() // to keep order consistent in different builds
     .forEach((originClass) => {
       const patchedClass = exports[originClass].name;
-      cssModulesJSON[camelCase(originClass)] = patchedClass;
+      let name = camelCase(originClass);
+
+      if (options.usePascalCase) {
+        name = upperFirst(name)
+      }
+
+      cssModulesJSON[name] = patchedClass;
     });
   const classNamesMapString = JSON.stringify(cssModulesJSON);
 


### PR DESCRIPTION
Previously, CSS class could be named `.Root` and exported with `Root` with localsConvention sets to "camelCase" or "camelCaseOnly". When `v2` is enabled, this is not the case anymore.

I added an option `usePascalCase` which is camel case with the first letter in uppercase.