### PR TITLE
skip generating build ID when `inject` is `false`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -73,7 +73,7 @@ declare interface PluginOptions {
 }
 
 declare interface BuildContext {
-  buildId: string;
+  buildId?: string;
   buildRoot: string;
   packageRoot?: string;
   packageVersion: string;

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -137,7 +137,7 @@ export default new Proxy(${classNamesMapString}, {
  * @return {Promise<void>}
  */
 const prepareBuild = async (build, options) => {
-  const buildId = await getBuildId(build);
+  const buildId = options.inject ? await getBuildId(build) : undefined;
   const packageVersion = getPackageVersion(build);
   build.initialOptions.metafile = true;
   const packageRoot = options.root;
@@ -155,7 +155,7 @@ const prepareBuild = async (build, options) => {
   };
   build.context.cache = new BuildCache(build);
 
-  log(`root of this build(#${buildId}):`, buildRoot);
+  log(`root of this build${buildId ? `(#${buildId})` : ''}:`, buildRoot);
 };
 
 /**
@@ -320,6 +320,12 @@ const onEnd = async (build, options, result) => {
   const log = getLogger(build);
 
   if (options.inject) {
+    if (!buildId) {
+      throw new Error(
+        "Internal error: buildId must be generated during setup when options.inject is enabled"
+      );
+    }
+
     const {
       charset = 'utf8',
       outdir,


### PR DESCRIPTION
I ran into a couple of issues with the `getBuildId` logic — see #45 and #46.

Digging into this further, I found that the build ID is only used when the `inject` option is set to `true`, but in my case it's set to `false`.

As a simple hot-fix I realised it's possible to skip generating the build ID entirely if we're outputting static CSS, meaning that any errors in the build ID logic are now irrelevant for my use case.

Ideally the issues with `getBuildId` should be fixed too, but they're a bit more involved than this simple fix.