### PR TITLE
Fix mutation of build.initialOptions

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,6 @@ import { patchContext } from './lib/context.js';
  * @param {import('./index.js').Options} _options
  */
 export const setup = (build, _options) => {
-  build.initialOptions.metafile = true;
   const options = _options || {};
   validateOptions(options);
 

--- a/lib/context.js
+++ b/lib/context.js
@@ -10,9 +10,6 @@ export const patchContext = (_build, options = {}) => {
   /** @type {import('../index.js').Build} */
   // @ts-ignore
   const build = _build;
-  build.initialOptions.metafile = true;
-  build.initialOptions.outbase ??= '.';
-
   const buildId = getBuildId(build);
   const { name, version } = getPackageInfo(build, options || {});
   const buildRoot = getRootDir(build);


### PR DESCRIPTION
Mutation of `build.initialOptions` causes unpredictable behavior and makes the functions not pure e. g. it affects on bazel rules https://docs.aspect.build/rulesets/aspect_rules_esbuild/docs/esbuild because `build.initialOptions.metafile = true` is set in the plugin.